### PR TITLE
Output abi, networks and bytecode to different json files during packaging

### DIFF
--- a/scripts/package-npm.js
+++ b/scripts/package-npm.js
@@ -12,56 +12,56 @@ const mapDirs = {
 // source file relative to repo root => dest file relative to module root
 //                                or => key to extract from source file => dest file relative to module root
 const mapFiles = {
-	"contracts/SingularityNetToken.sol": "sol/SingularityNetToken.sol",
-		"resources/SingularityNetToken.json": {
-		"abi": "abi/SingularityNetToken.json",
-		"networks": "networks/SingularityNetToken.json",
-		"bytecode": "bytecode/SingularityNetToken.json"
-	},
-	"resources/npm-README.md": "README.md",
-	"LICENSE": "LICENSE"
+    "contracts/SingularityNetToken.sol": "sol/SingularityNetToken.sol",
+    "resources/SingularityNetToken.json": {
+        "abi": "abi/SingularityNetToken.json",
+        "networks": "networks/SingularityNetToken.json",
+        "bytecode": "bytecode/SingularityNetToken.json"
+    },
+    "resources/npm-README.md": "README.md",
+    "LICENSE": "LICENSE"
 };
 
 let transformPackageJson = (x) => {
-	return {
-		name: x.name,
-		version: x.version,
-		description: x.description,
-		repository: x.repository,
-		author: x.author,
-		license: x.license,
-		bugs: x.bugs,
-		homepage: x.homepage,
-		dependencies: {
-			"zeppelin-solidity": x.dependencies["zeppelin-solidity"]
-		}
-	};
+    return {
+        name: x.name,
+        version: x.version,
+        description: x.description,
+        repository: x.repository,
+        author: x.author,
+        license: x.license,
+        bugs: x.bugs,
+        homepage: x.homepage,
+        dependencies: {
+            "zeppelin-solidity": x.dependencies["zeppelin-solidity"]
+        }
+    };
 };
 
 fse.removeSync(npmModulePath);
 fse.mkdirsSync(npmModulePath);
 
 for (let sourceDir in mapDirs) {
-	let destDir = path.join(npmModulePath, mapDirs[sourceDir]);
-	let destParent = path.resolve(destDir, "../");
-	fse.mkdirsSync(destParent);
-	fse.copySync(sourceDir, destDir);
+    let destDir = path.join(npmModulePath, mapDirs[sourceDir]);
+    let destParent = path.resolve(destDir, "../");
+    fse.mkdirsSync(destParent);
+    fse.copySync(sourceDir, destDir);
 }
 
 for (let sourceFile in mapFiles) {
-	if (mapFiles[sourceFile] !== null && typeof mapFiles[sourceFile] === "object") {
-		for (key in mapFiles[sourceFile]) {
-			let destFile = path.join(npmModulePath, mapFiles[sourceFile][key]);
-			let destParent = path.resolve(destFile, "../");
-			fse.mkdirsSync(destParent);
-			fse.writeJsonSync(destFile, fse.readJsonSync(sourceFile)[key]);
-		}
-	} else {
-		let destFile = path.join(npmModulePath, mapFiles[sourceFile]);
-		let destParent = path.resolve(destFile, "../");
-		fse.mkdirsSync(destParent);
-		fse.copySync(sourceFile, destFile);
-	}
+    if (mapFiles[sourceFile] !== null && typeof mapFiles[sourceFile] === "object") {
+        for (key in mapFiles[sourceFile]) {
+            let destFile = path.join(npmModulePath, mapFiles[sourceFile][key]);
+            let destParent = path.resolve(destFile, "../");
+            fse.mkdirsSync(destParent);
+            fse.writeJsonSync(destFile, fse.readJsonSync(sourceFile)[key]);
+        }
+    } else {
+        let destFile = path.join(npmModulePath, mapFiles[sourceFile]);
+        let destParent = path.resolve(destFile, "../");
+        fse.mkdirsSync(destParent);
+        fse.copySync(sourceFile, destFile);
+    }
 }
 
 let packageJsonIn = fse.readJsonSync(packageJson);


### PR DESCRIPTION
Exporting abi, networks and bytecode as separate JSON files
Changed package-npm.js script to take either a string with a file path or an object as the value for the source files map.

If an object is provided, each key will represent a key in the JSON source file that you want to save in a separate output file, and its value will be the destination file.